### PR TITLE
Refactor main layout and update home page redirect

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,0 +1,20 @@
+import SideBar from "@/components/layout/sideBar";
+import TopBar from "@/components/layout/topBar";
+import React from "react";
+
+const Pagelayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <SideBar />
+      {/* Main content area - Only needs margin on mobile/tablet */}
+      <div className="flex-1 bg-[var(--background)] flex flex-col overflow-hidden ml-16 sm:ml-20 lg:ml-0">
+        {/* Top Bar */}
+        <TopBar />
+        {/* Main content */}
+        <div className="p-4 sm:p-12 flex-1 overflow-auto">{children}</div>
+      </div>
+    </div>
+  );
+};
+
+export default Pagelayout;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,6 @@
-import TopBar from "@/components/layout/topBar";
-import SideBar from "@/components/layout/sideBar";
+import { redirect } from "next/navigation";
 
 export default function Home() {
-  return (
-    <div className="flex h-screen overflow-hidden">
-      <SideBar />
-      {/* Main content area - Only needs margin on mobile/tablet */}
-      <div className="flex-1 bg-[var(--background)] flex flex-col overflow-hidden ml-16 sm:ml-20 lg:ml-0">
-        {/* Top Bar */}
-        <TopBar />
-        {/* Main content */}
-        <div className="p-4 sm:p-12 flex-1 overflow-auto">
-          <h1 className="text-xl sm:text-2xl font-bold mb-4">Dashboard</h1>
-          <p className="text-sm sm:text-base">
-            Welcome to the Maldives Admin Dashboard!
-          </p>
-        </div>
-      </div>
-    </div>
-  );
+  redirect("/login");
+  return;
 }


### PR DESCRIPTION
Moved the main layout structure to a new Pagelayout component in (main)/layout.tsx. Deleted the redundant (main)/page.tsx and updated the root page to redirect to /login instead of rendering the dashboard layout.